### PR TITLE
ADSECGH-188: Assembly Load Fix for Rhino 8

### DIFF
--- a/AdSecCore/Constants/AdSecFileHelper.cs
+++ b/AdSecCore/Constants/AdSecFileHelper.cs
@@ -12,14 +12,22 @@ namespace AdSecCore.Constants {
   public class AdSecDllLoader {
 
     private Assembly _adSecAPI;
+    public Assembly Custom { get; set; }
 
     public Assembly AdSecAPI() {
       if (_adSecAPI == null) {
         switch (_Mode) {
 #pragma warning disable S3885 // Avoid using Assembly.LoadFrom
-          case LoadMode.LoadFrom: _adSecAPI = Assembly.LoadFrom("AdSec_API.dll"); break;
+          case LoadMode.LoadFrom:
+            _adSecAPI = Assembly.LoadFrom("AdSec_API.dll");
+            break;
 #pragma warning restore S3885
-          case LoadMode.Load: _adSecAPI = Assembly.Load("AdSec_API.dll"); break;
+          case LoadMode.Load:
+            _adSecAPI = Assembly.Load("AdSec_API.dll");
+            break;
+          case LoadMode.Custom:
+            _adSecAPI = Custom;
+            break;
         }
       }
 
@@ -30,7 +38,8 @@ namespace AdSecCore.Constants {
 
     public enum LoadMode {
       LoadFrom,
-      Load
+      Load,
+      Custom,
     }
 
     public AdSecDllLoader(LoadMode mode) {
@@ -42,9 +51,12 @@ namespace AdSecCore.Constants {
 
     // This needs to be changed on Tests
     public static AdSecDllLoader.LoadMode LoadMode { get; set; } = AdSecDllLoader.LoadMode.Load;
+    public static Assembly Custom { get; set; } = null;
 
     private static Dictionary<string, Type> ReflectAdSecNamespace(string @namespace) {
-      var adsecAPI = new AdSecDllLoader(LoadMode).AdSecAPI();
+      var adSecDllLoader = new AdSecDllLoader(LoadMode);
+      adSecDllLoader.Custom = Custom;
+      var adsecAPI = adSecDllLoader.AdSecAPI();
       var q = from t in adsecAPI.GetTypes() where t.IsInterface && t.Namespace == @namespace select t;
       var dict = new Dictionary<string, Type>();
       foreach (var typ in q) {

--- a/AdSecGH/AddReferenceProperty.cs
+++ b/AdSecGH/AddReferenceProperty.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Reflection;
 using System.Text;
 
+using AdSecCore.Constants;
+
 using AdSecGH.Graphics.Menu;
 using AdSecGH.Properties;
 
@@ -59,6 +61,8 @@ namespace AdSecGH {
 #pragma warning disable S2696 // Instance members should not write to "static" fields
 #pragma warning disable S3885 // "Assembly.Load" should be used - we must use LoadFile to load the dll from the plugin folder, without that our tests will not work
         AdSecAPI = Assembly.LoadFile($"{PluginPath}\\AdSec_API.dll");
+        AdSecFileHelper.LoadMode = AdSecDllLoader.LoadMode.Custom;
+        AdSecFileHelper.Custom = AdSecAPI;
 #pragma warning restore S3885 // "Assembly.Load" should be used
 #pragma warning restore S2696 // Instance members should not write to "static" fields
       } catch (Exception ex) {

--- a/AdSecGHTests/AddReferencePropertyTests.cs
+++ b/AdSecGHTests/AddReferencePropertyTests.cs
@@ -1,0 +1,27 @@
+﻿using AdSecCore.Constants;
+
+using AdSecGH;
+
+using Xunit;
+
+namespace AdSecGHTests {
+  [Collection("GrasshopperFixture collection")]
+  public class AddReferencePropertyTests {
+
+    public AddReferencePropertyTests() {
+      var priority = new AddReferencePriority();
+      priority.PriorityLoad();
+    }
+
+    [Fact]
+    public void ShouldHaveAValidAdSecAssembly() {
+      Assert.NotNull(AddReferencePriority.AdSecAPI);
+    }
+
+    [Fact]
+    public void ShouldHaveTheSameReference() {
+      Assert.Equal(AddReferencePriority.AdSecAPI, AdSecFileHelper.Custom);
+    }
+
+  }
+}


### PR DESCRIPTION
- **fix(AdSecFileHelper): added custom Assembly Load to be used from GH on Rhino 8**
- **test(AddReferencePropertyTests): added simple tests check lines run properly**
