### PR TITLE
Updated runs on label in github-release-yak.yml

### DIFF
--- a/.github/workflows/github-release-yak.yml
+++ b/.github/workflows/github-release-yak.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pushYakPackage:
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       YAK_TOKEN: ${{ secrets.YAK_TOKEN }} 
     steps:


### PR DESCRIPTION
OVERVIEW

The "windows-latest" label in GitHub Actions will be migrated to the Windows Server 2025 runner image.

This change will be rolled out over a period of several weeks beginning September 2, 2025 and will complete by September 30, 2025.

During this period your workflows will gradually switch over to the new image, once they are migrated they will not run on Windows Server 2022 in any future runs.

[IMPORTANT] The Windows Server 2025 image may have different tools installed than Windows Server 2022. You can check the [tool list for Windows 2025](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md?elqTrackId=086c2bda1209481a8e3e7b1fb946df0e&elq=299c6452dcf946e6877bc6becedc70bc&elqaid=4573&elqat=1&elqCampaignId=4763&elqak=8AF5E363CAA3D05433FD8CF75B89A0C1E242F81B8B0345E75A885815429984565CC3) to proactively identify any tooling differences and make updates to your workflows accordingly.

What you need to do:

You do not need to do anything at this time if you want your workflows to migrate to the latest windows version. If you want to remain on Windows 2022 you can follow the below instructions.

Switch your workflows to use the windows-2022 label by changing workflow YAML to use runs-on: windows-2022. We support the two latest stable windows versions plus latest beta, so windows 2022 will be maintained for the next 3 years.

So please either accept or reject the PR based on your requirements.

**Accept**: if your workflow indeed has to run on windows 2022 based runner
**Reject**: if you don't mind your workflow running on windows 2025 latest runner